### PR TITLE
Define WP_ADMIN only in a test which need to run admin behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ env:
 before_script:
 - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 - bash bin/prepare.sh
+- composer install
 script:
-- phpunit
+- vendo/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_script:
 - bash bin/prepare.sh
 - composer install
 script:
-- vendo/bin/phpunit
+- vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpunit/phpunit": "5.6"
+    }
+}

--- a/tests/phpunit/test-wp-multibyte-patch.php
+++ b/tests/phpunit/test-wp-multibyte-patch.php
@@ -1,6 +1,5 @@
 <?php
 
-define( 'WP_ADMIN', true );
 class WP_Multibyte_Patch_Test extends WP_UnitTestCase
 {
     public function setUp()
@@ -46,6 +45,8 @@ class WP_Multibyte_Patch_Test extends WP_UnitTestCase
 	 * The length of the draft's summary should be 40.
 	 */
 	function test_wp_dashboard_recent_drafts_length_should_be_40() {
+		define( 'WP_ADMIN', true );
+
 		$content = str_repeat( 'あ', 50 );
 		$content_summary = wp_trim_words( $content, 10,  '&hellip;' );
 

--- a/tests/phpunit/test-wp-multibyte-patch.php
+++ b/tests/phpunit/test-wp-multibyte-patch.php
@@ -43,6 +43,9 @@ class WP_Multibyte_Patch_Test extends WP_UnitTestCase
 
 	/**
 	 * The length of the draft's summary should be 40.
+	 *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
 	 */
 	function test_wp_dashboard_recent_drafts_length_should_be_40() {
 		define( 'WP_ADMIN', true );


### PR DESCRIPTION
We shouldn't always define `WP_ADMIN`, because some tests need to run on frontend or so. 😊 