### PR TITLE
Add test for length and italic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vendor
 composer.lock
 .plugin
 .lang
+.idea

--- a/tests/phpunit/test-wp-multibyte-patch.php
+++ b/tests/phpunit/test-wp-multibyte-patch.php
@@ -53,6 +53,36 @@ class WP_Multibyte_Patch_Test extends WP_UnitTestCase
 		$this->assertEquals( $expect, $content_summary );
 	}
 
+	/**
+	 * The length of the comment on dashboard should be 40.
+	 */
+	function test_length_of_comment_excerpt_should_be_40()
+	{
+		$post_id = self::factory()->post->create();
+		$args = array(
+			'comment_content' => str_repeat( 'あ', 100 ),
+		);
+
+		$comment_id = self::factory()->comment->create_post_comments( $post_id, 1 , $args );
+		$comment = self::factory()->comment->get_object_by_id( $comment_id[0] );
+		$this->expectOutputString( str_repeat( 'あ', 40 ) . '&hellip;' );
+		comment_excerpt( $comment );
+	}
+
+	/**
+	 * Confirm if italic font has been disabled.
+	 * Just check if it's imported css file.
+	 */
+	function test_if_disabled_italic_font_style()
+	{
+		$multibyte_patch_ext = new multibyte_patch_ext();
+		$multibyte_patch_ext->admin_custom_css();
+
+		$expect = "<link rel='stylesheet' id='wpmp-admin-custom-css'  href='http://example.org/wp-content/plugins/private/var/folders/c4/36002rhx55x_lxlhmz8sg12m0000gn/T/wordpress-tests-lib/data/wp-multibyte-patch/ext/ja/admin.css?ver=20131223' type='text/css' media='all' />";
+
+		$this->assertContains( $expect, get_echo( 'wp_print_styles' ) );
+	}
+
     /**
      * Add post and post be set to current.
      *

--- a/tests/phpunit/test-wp-multibyte-patch.php
+++ b/tests/phpunit/test-wp-multibyte-patch.php
@@ -78,7 +78,7 @@ class WP_Multibyte_Patch_Test extends WP_UnitTestCase
 		$multibyte_patch_ext = new multibyte_patch_ext();
 		$multibyte_patch_ext->admin_custom_css();
 
-		$expect = "<link rel='stylesheet' id='wpmp-admin-custom-css'  href='http://example.org/wp-content/plugins/private/var/folders/c4/36002rhx55x_lxlhmz8sg12m0000gn/T/wordpress-tests-lib/data/wp-multibyte-patch/ext/ja/admin.css?ver=20131223' type='text/css' media='all' />";
+		$expect = "/wordpress-tests-lib/data/wp-multibyte-patch/ext/ja/admin.css?ver=20131223'";
 
 		$this->assertContains( $expect, get_echo( 'wp_print_styles' ) );
 	}


### PR DESCRIPTION
- [x] The length of comment in dashboard should be 40.
- [x] We don't need italic in dashboard.